### PR TITLE
Add optional beta LAN server mode for OpenCode clients

### DIFF
--- a/ha_opencode/Dockerfile
+++ b/ha_opencode/Dockerfile
@@ -92,6 +92,7 @@ COPY rootfs /
 RUN chmod +x /usr/local/bin/* \
     && chmod +x /etc/s6-overlay/s6-rc.d/init-opencode/run \
     && chmod +x /etc/s6-overlay/s6-rc.d/ha-opencode/run \
+    && chmod +x /etc/s6-overlay/s6-rc.d/ha-opencode-server/run \
     && chmod +x /etc/profile.d/hab-esphome.sh \
     && chmod +x /etc/profile.d/zigporter-z2m.sh \
     && mkdir -p /data/.local/share/opencode /data/.config/opencode

--- a/ha_opencode/rootfs/etc/s6-overlay/s6-rc.d/ha-opencode-server/dependencies.d/init-opencode
+++ b/ha_opencode/rootfs/etc/s6-overlay/s6-rc.d/ha-opencode-server/dependencies.d/init-opencode
@@ -1,0 +1,1 @@
+# dependency marker

--- a/ha_opencode/rootfs/etc/s6-overlay/s6-rc.d/ha-opencode-server/run
+++ b/ha_opencode/rootfs/etc/s6-overlay/s6-rc.d/ha-opencode-server/run
@@ -1,0 +1,36 @@
+#!/command/with-contenv bashio
+# ==============================================================================
+# OpenCode - Optional LAN Server Service
+# ==============================================================================
+
+export HOME="/data"
+export XDG_DATA_HOME="/data/.local/share"
+export XDG_CONFIG_HOME="/data/.config"
+
+if [ -f /data/.env_vars ]; then
+    source /data/.env_vars
+fi
+
+ENABLE_SERVER=$(bashio::config 'enable_server' 2>/dev/null || echo "false")
+SERVER_PORT=4096
+
+if ! bashio::var.true "${ENABLE_SERVER}"; then
+    exec sleep infinity
+fi
+
+HOST_PORT=$(bashio::addon.port "${SERVER_PORT}" 2>/dev/null || true)
+
+bashio::log.info "LAN server config: ENABLE_SERVER=${ENABLE_SERVER} INTERNAL_PORT=${SERVER_PORT} HOST_PORT=${HOST_PORT:-unmapped}"
+bashio::log.warning "LAN server mode is enabled. OpenCode will listen on 0.0.0.0:${SERVER_PORT} inside the container."
+bashio::log.warning "Only map this port on trusted networks. Do not expose it to the internet."
+if bashio::var.has_value "${HOST_PORT}"; then
+    bashio::log.info "Home Assistant port mapping: ${SERVER_PORT}/tcp -> ${HOST_PORT}"
+    bashio::log.info "Connect from another computer with: opencode attach http://<home-assistant-host>:${HOST_PORT}"
+else
+    bashio::log.warning "Home Assistant port mapping for ${SERVER_PORT}/tcp is disabled; LAN clients cannot connect yet."
+    bashio::log.info "Map ${SERVER_PORT}/tcp in the add-on Network settings, then connect with: opencode attach http://<home-assistant-host>:<mapped-host-port>"
+fi
+bashio::log.info "If OpenCode prints http://0.0.0.0:${SERVER_PORT}, that is the internal container listener."
+bashio::log.info "Starting OpenCode LAN server: opencode serve --hostname 0.0.0.0 --port ${SERVER_PORT}"
+
+exec opencode serve --hostname 0.0.0.0 --port "${SERVER_PORT}"

--- a/ha_opencode/rootfs/etc/s6-overlay/s6-rc.d/ha-opencode-server/run
+++ b/ha_opencode/rootfs/etc/s6-overlay/s6-rc.d/ha-opencode-server/run
@@ -6,6 +6,7 @@
 export HOME="/data"
 export XDG_DATA_HOME="/data/.local/share"
 export XDG_CONFIG_HOME="/data/.config"
+export NODE_OPTIONS="--max-old-space-size=512"
 
 if [ -f /data/.env_vars ]; then
     source /data/.env_vars
@@ -33,4 +34,5 @@ fi
 bashio::log.info "If OpenCode prints http://0.0.0.0:${SERVER_PORT}, that is the internal container listener."
 bashio::log.info "Starting OpenCode LAN server: opencode serve --hostname 0.0.0.0 --port ${SERVER_PORT}"
 
+cd /homeassistant
 exec opencode serve --hostname 0.0.0.0 --port "${SERVER_PORT}"

--- a/ha_opencode/rootfs/etc/s6-overlay/s6-rc.d/ha-opencode-server/type
+++ b/ha_opencode/rootfs/etc/s6-overlay/s6-rc.d/ha-opencode-server/type
@@ -1,0 +1,1 @@
+longrun

--- a/ha_opencode/rootfs/etc/s6-overlay/s6-rc.d/user/contents.d/ha-opencode-server
+++ b/ha_opencode/rootfs/etc/s6-overlay/s6-rc.d/user/contents.d/ha-opencode-server
@@ -1,0 +1,1 @@
+# service marker

--- a/ha_opencode_beta/DOCS.md
+++ b/ha_opencode_beta/DOCS.md
@@ -8,6 +8,7 @@ This is the **beta channel** for the OpenCode add-on. It contains experimental f
 
 - **Beta baseline reset**: `1.9.0b0` is based on the current stable OpenCode add-on release and does not include beta-only feature changes yet.
 - **Serial device access**: Selected host UART/serial devices can be mapped into the add-on for USB flashing and adapter inspection workflows. Full Supervisor `uart` and `udev` manifest flags remain disabled by default because they are static permissions, not runtime user options.
+- **Optional LAN server mode**: You can now enable an OpenCode server bound to `0.0.0.0` so other computers on your local network can connect directly.
 
 ## Add-on Folder Access
 
@@ -22,6 +23,32 @@ OpenCode snapshots are disabled by default in this add-on to reduce memory and d
 ## Zigbee2MQTT URL
 
 If you configure `z2m_url` for zigporter commands, use a full URL such as `http://homeassistant.local:8099`. Host/IP-only values are accepted and treated as `http://`.
+
+## LAN Server Mode (Beta)
+
+LAN server mode lets you attach to the Home Assistant-hosted OpenCode session from a terminal outside the Home Assistant UI.
+
+To enable LAN access:
+
+1. In the add-on **Configuration** tab, set **Enable OpenCode LAN Server** to `true`.
+2. In the add-on **Network** settings, map `4096/tcp` to the host port you want to use.
+3. Save and restart the add-on.
+
+On the secondary computer, use `opencode attach` with your Home Assistant host IP and configured port:
+
+```bash
+opencode attach http://<home-assistant-ip>:<mapped-host-port>
+```
+
+Example, if you mapped `4096/tcp` to host port `4096`:
+
+```bash
+opencode attach http://192.168.1.50:4096
+```
+
+The add-on log shows the current Home Assistant port mapping when the server starts, for example `Home Assistant port mapping: 4096/tcp -> 3443`. If OpenCode also prints `opencode server listening on http://0.0.0.0:4096`, that is the internal container listener, not the URL to use from another computer. Use your Home Assistant host and the mapped host port instead.
+
+Security warning: enabling this service and mapping the port exposes an OpenCode server on your LAN. Only use this on trusted networks, restrict access with your network/firewall controls, and never expose the port to the internet or untrusted networks.
 
 ## Reporting Issues
 

--- a/ha_opencode_beta/config.yaml
+++ b/ha_opencode_beta/config.yaml
@@ -17,6 +17,10 @@ ingress_port: 8099
 ingress_stream: true
 panel_icon: mdi:robot-outline
 panel_title: OpenCode Beta
+ports:
+  4096/tcp: null
+ports_description:
+  4096/tcp: "OpenCode LAN server"
 
 # File access - Home Assistant config directory
 map:
@@ -66,6 +70,10 @@ options:
   # Enable this to show add-on development guidance in the terminal.
   addon_access_enabled: false
 
+  # Optional LAN server mode for remote OpenCode clients.
+  # Warning: If you map 4096/tcp in Network settings, this exposes an OpenCode server on your LAN.
+  enable_server: false
+
   # Long-lived access token for direct HA Core API access.
   # Required for ESPHome ingress and screenshot tool (create at: Profile → Long-Lived Access Tokens).
   # Leave empty if you don't use ESPHome or screenshot tools.
@@ -106,6 +114,9 @@ schema:
 
   # Add-on development access acknowledgement
   addon_access_enabled: bool
+
+  # OpenCode LAN server mode
+  enable_server: bool
 
   # HA Core access token
   access_token: str?

--- a/ha_opencode_beta/translations/en.yaml
+++ b/ha_opencode_beta/translations/en.yaml
@@ -36,6 +36,10 @@ configuration:
     name: "Enable Add-on Folder Guidance"
     description: "Show guidance for working with Home Assistant add-on folders. Security note: /addons and /addon_configs are mounted into this add-on for development access, and /addon_configs may contain sensitive add-on data. Changing this option requires restarting the add-on to update terminal guidance, but it is not a hard filesystem permission boundary."
 
+  enable_server:
+    name: "Enable OpenCode LAN Server"
+    description: "Start an OpenCode server on internal port 4096. To access it from another computer, also map 4096/tcp in the Network settings. Only use this on trusted networks and never expose it to the internet."
+
   access_token:
     name: "Home Assistant Access Token"
     description: "A long-lived access token for direct communication with Home Assistant Core. Required for ESPHome integration and the screenshot tool. Create one in the HA UI under Profile → Long-Lived Access Tokens. Leave empty if you don't use ESPHome or screenshot tools."


### PR DESCRIPTION
## Summary

Adds an optional LAN server mode to the OpenCode Beta add-on so users can attach from a terminal outside the Home Assistant UI:

```bash
opencode attach http://<home-assistant-host>:<mapped-host-port>
```

This gives users a more flexible workflow than the ingress browser terminal alone: they can use their preferred local terminal, shell environment, multiplexers, and workstation setup while connecting back to the Home Assistant-hosted OpenCode server.

## Changes

- Adds an opt-in beta configuration switch for starting the LAN server.
- Uses fixed internal port `4096` and lets Home Assistant Network settings control whether and where that port is mapped on the host.
- Sets `4096/tcp: null` by default so the host port is not reserved unless the user explicitly maps it.
- Runs `opencode serve --hostname 0.0.0.0 --port 4096` as a dedicated s6 longrun service instead of backgrounding it from the ttyd service.
- Removes the separate `server_port` option so the internal listener and Home Assistant port mapping cannot drift apart.
- Logs the active Home Assistant host-port mapping when LAN server mode is enabled, and stays quiet when the LAN server is disabled.
- Documents the two-step enablement flow and includes a stronger LAN exposure warning.
- Leaves stable add-on metadata unchanged so maintainers can decide separately whether to promote the option beyond beta.

## Validation

- Built and tested from a forked beta add-on image.
- Confirmed the server starts with `--hostname 0.0.0.0` for the current OpenCode CLI.
- Confirmed `opencode attach http://<home-assistant-host>:<mapped-host-port>` connects from another machine after enabling the option and mapping `4096/tcp`.
- Confirmed alternate mapped host ports work as expected.
