### PR TITLE
ci: automate opencode/openchamber pin update PRs

### DIFF
--- a/.github/workflows/check-upstream-opencode-openchamber.yaml
+++ b/.github/workflows/check-upstream-opencode-openchamber.yaml
@@ -1,0 +1,67 @@
+---
+name: Check upstream opencode/openchamber updates
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-upstream:
+    name: Open PR when upstream packages change
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Check pinned versions against npm latest
+        id: check
+        run: |
+          set +e
+          scripts/check-upstream-versions.py
+          STATUS=$?
+          set -e
+
+          if [ "$STATUS" -eq 2 ]; then
+            echo "has_updates=true" >> "$GITHUB_OUTPUT"
+          elif [ "$STATUS" -eq 0 ]; then
+            echo "has_updates=false" >> "$GITHUB_OUTPUT"
+          else
+            exit "$STATUS"
+          fi
+
+      - name: Update pinned versions
+        if: steps.check.outputs.has_updates == 'true'
+        run: scripts/check-upstream-versions.py --update
+
+      - name: Create pull request
+        if: steps.check.outputs.has_updates == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore: bump opencode/openchamber pins"
+          title: "chore: bump opencode/openchamber pins"
+          body: |
+            This automated PR updates pinned package versions used by both add-on channels.
+
+            - Always updates `OPENCODE_VERSION` (`opencode-ai`)
+            - Also updates `OPENCHAMBER_VERSION` (`@openchamber/web`) when that pin exists in `build.yaml`
+
+            The workflow runs daily and opens/updates this PR only when upstream npm versions change.
+          branch: ci/bump-upstream-opencode-openchamber
+          delete-branch: true
+          labels: |
+            dependencies
+            automation
+          add-paths: |
+            ha_opencode/build.yaml
+            ha_opencode_beta/build.yaml

--- a/scripts/check-upstream-versions.py
+++ b/scripts/check-upstream-versions.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+STABLE_BUILD = ROOT / "ha_opencode" / "build.yaml"
+BETA_BUILD = ROOT / "ha_opencode_beta" / "build.yaml"
+
+
+def get_latest_version(package_name: str) -> str:
+    url = f"https://registry.npmjs.org/{package_name}/latest"
+    req = urllib.request.Request(url, headers={"User-Agent": "opencode-addon-ci"})
+    with urllib.request.urlopen(req) as response:
+        data = json.loads(response.read().decode("utf-8"))
+    return data["version"]
+
+
+def get_pinned_version(path: Path, key: str):
+    pattern = re.compile(rf"^\s*{re.escape(key)}:\s*\"([^\"]+)\"\s*$")
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = pattern.match(line)
+        if match:
+            return match.group(1)
+    return None
+
+
+def set_pinned_version(path: Path, key: str, value: str) -> bool:
+    pattern = re.compile(rf"^(\s*{re.escape(key)}:\s*\")[^\"]+(\"\s*)$")
+    changed = False
+    out_lines = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = pattern.match(line)
+        if match:
+            new_line = f"{match.group(1)}{value}{match.group(2)}"
+            out_lines.append(new_line)
+            changed = changed or (new_line != line)
+        else:
+            out_lines.append(line)
+    if changed:
+        path.write_text("\n".join(out_lines) + "\n", encoding="utf-8")
+    return changed
+
+
+def main() -> int:
+    update = "--update" in sys.argv
+
+    latest_opencode = get_latest_version("opencode-ai")
+    latest_openchamber = get_latest_version("@openchamber/web")
+
+    stable_opencode = get_pinned_version(STABLE_BUILD, "OPENCODE_VERSION")
+    stable_openchamber = get_pinned_version(STABLE_BUILD, "OPENCHAMBER_VERSION")
+    beta_opencode = get_pinned_version(BETA_BUILD, "OPENCODE_VERSION")
+    beta_openchamber = get_pinned_version(BETA_BUILD, "OPENCHAMBER_VERSION")
+
+    needs_update = (
+        stable_opencode != latest_opencode
+        or beta_opencode != latest_opencode
+        or (stable_openchamber is not None and stable_openchamber != latest_openchamber)
+        or (beta_openchamber is not None and beta_openchamber != latest_openchamber)
+    )
+
+    print(f"Latest opencode-ai: {latest_opencode}")
+    print(f"Latest @openchamber/web: {latest_openchamber}")
+    print(f"Pinned stable: OPENCODE_VERSION={stable_opencode}, OPENCHAMBER_VERSION={stable_openchamber}")
+    print(f"Pinned beta:   OPENCODE_VERSION={beta_opencode}, OPENCHAMBER_VERSION={beta_openchamber}")
+
+    if not update:
+        if needs_update:
+            print("Update required")
+            return 2
+        print("No update required")
+        return 0
+
+    changed = False
+    changed = set_pinned_version(STABLE_BUILD, "OPENCODE_VERSION", latest_opencode) or changed
+    if stable_openchamber is not None:
+        changed = set_pinned_version(STABLE_BUILD, "OPENCHAMBER_VERSION", latest_openchamber) or changed
+    changed = set_pinned_version(BETA_BUILD, "OPENCODE_VERSION", latest_opencode) or changed
+    if beta_openchamber is not None:
+        changed = set_pinned_version(BETA_BUILD, "OPENCHAMBER_VERSION", latest_openchamber) or changed
+
+    if changed:
+        print("Updated build.yaml pins")
+    else:
+        print("Pins already up to date")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #38

## What this adds
- New scheduled workflow: `.github/workflows/check-upstream-opencode-openchamber.yaml`
- New helper script: `scripts/check-upstream-versions.py`

## Behavior
- Runs daily (plus manual `workflow_dispatch`)
- Checks npm latest for:
  - `opencode-ai`
  - `@openchamber/web`
- Compares those values with pins in:
  - `ha_opencode/build.yaml`
  - `ha_opencode_beta/build.yaml`
- If versions drift, automatically opens/updates a rolling PR using `peter-evans/create-pull-request`
- If no drift, exits without changes

## Notes
- The script updates OpenChamber pins only when `OPENCHAMBER_VERSION` exists in the target `build.yaml`, so it works with the repo state before and after OpenChamber pin introduction.
- This keeps version bump automation scoped to deterministic pin updates and avoids changing release/build publishing flow.