### PR TITLE
fix: auto-fit ttyd terminal to HA ingress iframe (#56)

### DIFF
--- a/ha_opencode/Dockerfile
+++ b/ha_opencode/Dockerfile
@@ -129,9 +129,9 @@ RUN chmod +x /usr/local/bin/* \
 
 # Build the custom ttyd index page (served via -I at runtime): ttyd's page is
 # a single self-contained HTML file compiled into the binary, so dump it from
-# a briefly-running instance and inject local browser-side fixes for clipboard
-# and touch scrolling. The injector fails the build if the page could not be
-# dumped or has an unexpected layout.
+# a briefly-running instance and inject local browser-side fixes for clipboard,
+# touch scrolling, and iframe auto-fit. The injector fails the build if the page
+# could not be dumped or has an unexpected layout.
 RUN set -e; \
     ttyd -p 18099 -i lo bash & \
     TTYD_PID=$!; \
@@ -142,7 +142,7 @@ RUN set -e; \
     done; \
     kill "$TTYD_PID"; \
     [ "$ok" = "1" ]; \
-    python3 /opt/ttyd/inject-clipboard.py /tmp/ttyd-index.html /opt/ttyd/index.html /opt/ttyd/clipboard.js /opt/ttyd/touch-scroll.js; \
+    python3 /opt/ttyd/inject-clipboard.py /tmp/ttyd-index.html /opt/ttyd/index.html /opt/ttyd/clipboard.js /opt/ttyd/touch-scroll.js /opt/ttyd/resize-fit.js; \
     rm -f /tmp/ttyd-index.html
 
 # Set working directory to HA config (mounted at runtime)

--- a/ha_opencode/rootfs/opt/ttyd/resize-fit.js
+++ b/ha_opencode/rootfs/opt/ttyd/resize-fit.js
@@ -1,0 +1,89 @@
+/*
+ * Auto-fit ttyd/xterm.js to the Home Assistant ingress iframe.
+ *
+ * Injected inline into ttyd's index page at image build time (see Dockerfile)
+ * alongside the clipboard and touch-scroll fixes. Closes a resize gap in stock
+ * ttyd 1.7.7 when it runs inside the HA ingress iframe.
+ *
+ * ttyd re-fits the terminal only from a window 'resize' event:
+ *
+ *     register(addEventListener(window, 'resize', () => fitAddon.fit()));
+ *
+ * Home Assistant, however, resizes the add-on iframe from its own JavaScript
+ * (toggling the sidebar, the initial panel layout) without the iframe's window
+ * ever firing 'resize'. So fitAddon.fit() never re-runs and the pane keeps its
+ * initial, oversized dimensions — content then overflows the viewport on the
+ * right and top (e.g. Ctrl+P's "Session" header sits above the visible area).
+ *
+ * We watch the document element with a ResizeObserver, which fires on the
+ * iframe-driven size changes that 'resize' misses, and call ttyd's own
+ * window.term.fit() to recompute cols/rows. Work is coalesced through
+ * requestAnimationFrame and gated on an actual dimension change, so redundant
+ * fits — and any ResizeObserver feedback loop — are avoided. This is additive
+ * to ttyd's stock window-resize handler, which keeps working when it does fire.
+ */
+(function () {
+  'use strict';
+
+  var rafId = 0;
+  var lastW = -1;
+  var lastH = -1;
+
+  function fitNow() {
+    rafId = 0;
+    if (!window.term || typeof window.term.fit !== 'function') return;
+    try {
+      window.term.fit();
+    } catch (error) {
+      // Never let optional auto-fit break the terminal.
+    }
+  }
+
+  function scheduleFit() {
+    if (rafId) return;
+    rafId = requestAnimationFrame(fitNow);
+  }
+
+  /* Only fit when the viewport actually changed size. The document element
+     tracks the iframe viewport and is not resized by fit() itself, so this
+     both suppresses no-op fits and prevents an observer feedback loop. */
+  function onGeometryChange() {
+    var el = document.documentElement;
+    var w = el.clientWidth;
+    var h = el.clientHeight;
+    if (w === lastW && h === lastH) return;
+    lastW = w;
+    lastH = h;
+    scheduleFit();
+  }
+
+  function setup() {
+    if (typeof ResizeObserver === 'function') {
+      new ResizeObserver(onGeometryChange).observe(document.documentElement);
+    }
+
+    /* Secondary signals for environments/gestures where neither the classic
+       window 'resize' nor the ResizeObserver fires reliably (mobile zoom,
+       on-screen keyboard, orientation change). */
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener('resize', scheduleFit);
+    }
+    window.addEventListener('orientationchange', scheduleFit);
+
+    /* Correct the initial, build-time-dumped dimensions right away, then once
+       more after first layout/connect settles. */
+    scheduleFit();
+    setTimeout(scheduleFit, 500);
+  }
+
+  /* ttyd exposes window.term (with our-side window.term.fit) once its app has
+     initialised; this script runs before that, so poll briefly (up to ~10s). */
+  var tries = 0;
+  (function waitForTerm() {
+    if (window.term && typeof window.term.fit === 'function') {
+      setup();
+    } else if (++tries < 200) {
+      setTimeout(waitForTerm, 50);
+    }
+  })();
+})();

--- a/ha_opencode_beta/CHANGELOG.md
+++ b/ha_opencode_beta/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.6b4
+
+- **Terminal now fits the Home Assistant iframe ([issue #56](https://github.com/magnusoverli/opencode/issues/56))** — the ingress terminal kept its initial oversized dimensions and overflowed on the right and top (for example, `Ctrl+P`'s "Session" header sat above the visible area), and toggling the HA sidebar did not reflow it. ttyd 1.7.7 re-fits the terminal only from a window `resize` event, but Home Assistant resizes the add-on iframe from its own JavaScript without ever firing one. A small injected browser-side script now watches the viewport with a `ResizeObserver` and calls ttyd's `window.term.fit()` on the iframe-driven size changes that `resize` misses, so the terminal reflows to the available space on load and when the sidebar toggles. Thanks to [@fmjensen](https://github.com/fmjensen) for the detailed report and root-cause analysis.
+
 ## 2.3.6b3
 
 - **Supervisor-safe Home Assistant logs ([issue #57](https://github.com/magnusoverli/opencode/issues/57))** — `ha-logs error` and the MCP `get_error_log` tool returned a 404 on Home Assistant instances running under Supervisor, which disables the file-backed `/api/error_log` endpoint in favor of journald. Both now fall back to Core's journal logs when the file-backed endpoint is unavailable. Thanks to [@GuiPoM](https://github.com/GuiPoM) for reporting it.

--- a/ha_opencode_beta/config.yaml
+++ b/ha_opencode_beta/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "OpenCode Beta"
 description: "Beta channel for OpenCode - AI coding agent for Home Assistant. May contain experimental features."
-version: "2.3.6b3"
+version: "2.3.6b4"
 slug: "ha_opencode_beta"
 image: "ghcr.io/magnusoverli/ha_opencode_beta"
 url: "https://github.com/magnusoverli/opencode"


### PR DESCRIPTION
## Summary

Fixes #56 — the ingress terminal kept its initial oversized dimensions and overflowed on the right and top (e.g. `Ctrl+P`'s "Session" header sat above the visible area), and toggling the HA sidebar did not reflow it.

## Root cause

ttyd 1.7.7 re-fits the terminal **only** from a window `resize` event:

```js
register(addEventListener(window, 'resize', () => fitAddon.fit()));
```

Home Assistant, however, resizes the add-on iframe from its **own** JavaScript (initial panel layout, sidebar toggle) without the iframe's `window` ever firing `resize`. So `fitAddon.fit()` never re-runs and the pane keeps its initial dimensions (the reported 373×126), overflowing the viewport. Thanks to @fmjensen for the detailed report and root-cause analysis.

## Fix

The add-on already patches ttyd's compiled-in index page at build time by splicing scripts before `</body>` (`inject-clipboard.py`, wired in the Dockerfile). This adds one more injected script following that same mechanism:

- **`ha_opencode/rootfs/opt/ttyd/resize-fit.js`** — waits for `window.term`, then observes `document.documentElement` with a `ResizeObserver` (which fires on the iframe-driven size changes that `resize` misses) and calls ttyd's own `window.term.fit()`. Coalesced via `requestAnimationFrame` and gated on an actual dimension change to avoid redundant fits and observer feedback loops. Additive to ttyd's stock window-resize handler; no-ops safely if a future ttyd drops the `window.term.fit` export. Secondary `visualViewport`/`orientationchange` signals plus an initial fit cover mobile zoom and the oversized first-load state.
- **`ha_opencode/Dockerfile`** — adds `resize-fit.js` to the injector invocation.

Both stable and beta build from the same `ha_opencode/` Dockerfile+rootfs, so the code change covers both. Released to the **beta channel first** (matching #57): `ha_opencode_beta` → **2.3.6b4** with a changelog entry.

## Verification

- `node --check` passes on the new script.
- Confirmed no `</script` token (the injector rejects that).
- Simulated the full `inject-clipboard.py` run with all three scripts: 3 blocks injected, `resize-fit` content present.

Not runtime-tested inside a live HA iframe (requires a build + install). Suggested manual check on a device: open the panel (should fit on load) and toggle the HA sidebar (should reflow).