### PR TITLE
fix: silence ttyd per-request NOTICE log spam

### DIFF
--- a/ha_opencode/rootfs/etc/s6-overlay/s6-rc.d/ha-opencode/run
+++ b/ha_opencode/rootfs/etc/s6-overlay/s6-rc.d/ha-opencode/run
@@ -133,8 +133,14 @@ bashio::log.info "Starting ttyd on port 8099 (Home Assistant ingress)..."
 # macOptionClickForcesSelection lets macOS users select text with Option+drag
 # while OpenCode has mouse reporting enabled (the Shift+drag override is
 # Windows/Linux-only in xterm.js).
+# -d 3 sets the libwebsockets log level to ERR|WARN only. ttyd's default is 7
+# (ERR|WARN|NOTICE), which logs every accepted HTTP connection at NOTICE — so
+# the container health check (curl http://127.0.0.1:8099/ every 30s) produced a
+# repeating three-line burst (__lws_lc_tag / HTTP / / __lws_lc_untag) that
+# spammed the add-on log ~4300 lines a day. Errors and warnings still surface.
 exec ttyd \
     -W \
+    -d 3 \
     -p 8099 \
     -I /opt/ttyd/index.html \
     -t fontSize="${FONT_SIZE}" \

--- a/ha_opencode_beta/CHANGELOG.md
+++ b/ha_opencode_beta/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.6b5
+
+- **Quieter add-on log** — ttyd logged every accepted HTTP connection at libwebsockets NOTICE level, so the container health check (which probes `http://127.0.0.1:8099/` every 30 seconds) produced a repeating three-line burst (`__lws_lc_tag` / `HTTP /` / `__lws_lc_untag`) — roughly 4,300 lines a day of noise that buried real messages. ttyd now runs at log level `ERR|WARN` (`-d 3`), so genuine errors and warnings still surface while the per-probe chatter is gone.
+
 ## 2.3.6b4
 
 - **Terminal now fits the Home Assistant iframe ([issue #56](https://github.com/magnusoverli/opencode/issues/56))** — the ingress terminal kept its initial oversized dimensions and overflowed on the right and top (for example, `Ctrl+P`'s "Session" header sat above the visible area), and toggling the HA sidebar did not reflow it. ttyd 1.7.7 re-fits the terminal only from a window `resize` event, but Home Assistant resizes the add-on iframe from its own JavaScript without ever firing one. A small injected browser-side script now watches the viewport with a `ResizeObserver` and calls ttyd's `window.term.fit()` on the iframe-driven size changes that `resize` misses, so the terminal reflows to the available space on load and when the sidebar toggles. Thanks to [@fmjensen](https://github.com/fmjensen) for the detailed report and root-cause analysis.

--- a/ha_opencode_beta/config.yaml
+++ b/ha_opencode_beta/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "OpenCode Beta"
 description: "Beta channel for OpenCode - AI coding agent for Home Assistant. May contain experimental features."
-version: "2.3.6b4"
+version: "2.3.6b5"
 slug: "ha_opencode_beta"
 image: "ghcr.io/magnusoverli/ha_opencode_beta"
 url: "https://github.com/magnusoverli/opencode"


### PR DESCRIPTION
## Summary

A user reported the add-on log filling with repeating libwebsockets NOTICE lines every 30 seconds:

```
N: __lws_lc_tag: ++ [wsisrv|54|adopted] (1)
N: HTTP / - 127.0.0.1
N: __lws_lc_untag: -- [wsisrv|54|adopted] (0) 2.162ms
```

## Root cause

Two of our own settings combine:

1. **ttyd runs at the libwebsockets default log level `7` (`ERR|WARN|NOTICE`)** — the `exec ttyd` invocation in `etc/s6-overlay/s6-rc.d/ha-opencode/run` had no `-d` flag. At NOTICE, lws logs every accepted HTTP connection and its lifecycle tag/untag.
2. **Our container health check probes ttyd every 30s** — `HEALTHCHECK --interval=30s ... curl -fsS http://127.0.0.1:8099/` in the Dockerfile. That is the `HTTP / - 127.0.0.1` request; the 30s cadence matches the report exactly (three lines per probe).

Nothing is broken — the health check is working as intended — but a healthy install emits ~4,300 NOTICE lines/day that bury real messages.

## Fix

Start ttyd with `-d 3` (`ERR|WARN` only). Genuine errors and warnings still surface; the per-probe NOTICE chatter is gone. This targets ttyd's verbosity rather than loosening the health check, which is doing its job.

Released to the beta channel first: `ha_opencode_beta` -> **2.3.6b5** with a changelog entry.

## Verification

- `bash -n` passes on the edited run script.
- Flag placement confirmed (`-W`, `-d 3`, `-p 8099`, ...).

Not runtime-tested against a live add-on (requires a build + install). Reported via forum, not a GitHub issue, so there is no issue number to link.