### PR TITLE
Add opencode-synced plugin to default config

### DIFF
--- a/ha_opencode/Dockerfile
+++ b/ha_opencode/Dockerfile
@@ -43,6 +43,7 @@ ENV NODE_ENV=production \
 # - tmux: Session persistence to prevent multiple OpenCode instances
 # - chromium: Headless browser for screenshot_url MCP tool (visual verification)
 # - g++/make: native fallback builds for OpenChamber dependencies on all arches
+# - gh: GitHub CLI, required by opencode-synced plugin for repo operations
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -59,6 +60,13 @@ RUN apt-get update \
         python3-venv \
         tmux \
     && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI (gh) for opencode-synced plugin
+# Required for cross-machine config sync via GitHub repos
+RUN ARCH=$([ "$BUILD_ARCH" = "aarch64" ] && echo "arm64" || echo "amd64") \
+    && curl -fsSL "https://github.com/cli/cli/releases/latest/download/gh_${ARCH}.deb" -o /tmp/gh.deb \
+    && dpkg -i /tmp/gh.deb \
+    && rm /tmp/gh.deb
 
 # Chromium path for puppeteer-core (used by screenshot MCP tool)
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium

--- a/ha_opencode/rootfs/opt/ha-mcp-server/opencode-ha.json
+++ b/ha_opencode/rootfs/opt/ha-mcp-server/opencode-ha.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "plugin": ["opencode-synced"],
   "snapshot": false,
   "permission": {
     "external_directory": {


### PR DESCRIPTION
## Summary

Adds the `opencode-synced` plugin to the default opencode configuration template (`opencode-ha.json`) and installs the required GitHub CLI (`gh`) in the Docker image.

## What is opencode-synced?

[opencode-synced](https://github.com/iHildy/opencode-synced) is a plugin that syncs the global opencode configuration (`~/.config/opencode`) across machines using a private GitHub repository.

### Features
- Syncs global opencode config (`~/.config/opencode`) and related directories
- Optional secrets sync for private repos
- Optional session sync to share conversation history across machines
- Optional prompt stash sync
- Startup auto-sync with restart toast
- Per-machine overrides via `opencode-synced.overrides.jsonc`
- Custom `/sync-*` commands and `opencode_sync` tool

## Why include it by default?

Users of this add-on typically run opencode on Home Assistant, which may be accessed from multiple devices or reinstalled periodically. Having the sync plugin available by default:

1. **Reduces setup friction** — users can enable sync with `/sync-init` instead of manually configuring plugins
2. **Preserves customizations** — agents, skills, themes, and MCP configs sync automatically
3. **No overhead** — the plugin is registered but does nothing until the user runs `/sync-init`

## Changes

### 1. Plugin registration
- `ha_opencode/rootfs/opt/ha-mcp-server/opencode-ha.json`: Added `"plugin": ["opencode-synced"]`

### 2. GitHub CLI installation
- `ha_opencode/Dockerfile`: Added `gh` installation for the target architecture
- Required dependency: opencode-synced uses `gh` for authenticated GitHub operations

## Dependencies

The opencode-synced plugin requires:
- **GitHub CLI (`gh`)** — now installed in the Docker image (see Dockerfile changes)
- **Git** — already present in the base image
- **User authentication** — users must run `gh auth login` after first boot to authenticate

## Testing

1. Build the add-on image
2. Install the add-on
3. Verify opencode starts without errors
4. Run `gh --version` to confirm GitHub CLI is installed
5. Run `gh auth login` to authenticate
6. Run `/sync-init` to confirm the plugin is active

## Documentation

See [opencode-synced README](https://github.com/iHildy/opencode-synced#readme) for full documentation.

---

*This PR adds the opencode-synced plugin with its required GitHub CLI dependency.*