### PR TITLE
fix(cpu): explain the SSE4.2 floor instead of crashing (#86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Simply run `/connect` and select **OpenCode Zen** to get started for free.
 
 ## 📦 Installation
 
+> ⚙️ **Hardware requirement:** on x86-64, OpenCode needs a CPU with **SSE4.2** (Intel Nehalem/2008 or newer, AMD Bulldozer/2011 or Jaguar/2013 or newer). Older processors cannot run it at all — it exits with `Illegal instruction (core dumped)`. ARM64 is unaffected. See [CPU requirements][cpu-req] for details.
+
 ### Quick Install
 
 1. **Add this repository to Home Assistant:**
@@ -329,6 +331,7 @@ This distribution also includes third-party software, including OpenCode. Its co
 
 <!-- Links -->
 [docs]: ./ha_opencode/DOCS.md
+[cpu-req]: ./ha_opencode/DOCS.md#cpu-requirements
 [changelog]: ./ha_opencode/CHANGELOG.md
 [issues]: https://github.com/magnusoverli/opencode/issues
 [license]: UNLICENSE

--- a/ha_opencode/DOCS.md
+++ b/ha_opencode/DOCS.md
@@ -119,7 +119,7 @@ Everything else stays fully readable, and this doesn't change how the agent edit
 | Option | Default | Description |
 |--------|---------|-------------|
 | **OpenCode update policy** | `bundled` | Controls how OpenCode itself is updated. `bundled` (default) uses the OpenCode version shipped in the add-on image — the lowest-memory option. `latest` follows upstream OpenCode releases, refreshed in the background so it never delays start-up and skipped automatically on low-memory systems. See [OpenCode Updates](#opencode-updates). |
-| **CPU mode** | `auto` | Controls which OpenCode binary is used. `auto` detects your CPU capabilities automatically (recommended). `baseline` forces the baseline binary for older CPUs without AVX2 support. `regular` forces the standard binary. |
+| **CPU mode** | `auto` | Controls which OpenCode binary is used. `auto` detects your CPU capabilities automatically (recommended). `baseline` selects the build intended for older CPUs without AVX2; `regular` forces the standard build. See [CPU requirements](#cpu-requirements) — OpenCode needs SSE4.2 in every mode, and upstream currently ships the same binary in both packages, so `baseline` does not presently rescue a CPU without AVX2. |
 
 ### Network Exposure
 
@@ -192,7 +192,16 @@ By default, **OpenCode update policy** is set to `bundled`: the add-on uses the 
 
 Set **OpenCode update policy** to `latest` to follow upstream OpenCode releases independently of add-on releases. The add-on starts immediately on the bundled (or an existing healthy persistent) binary, then refreshes `opencode-ai@latest` into `/data/.npm-global` **in the background**; the newer version becomes active for the next OpenCode session. The background update never blocks start-up, and it is skipped automatically when available memory is below ~1.5 GB so the install cannot push a low-memory host into swap-thrash. If an update is interrupted or produces a binary that will not run, the add-on discards it and keeps using the known-good bundled copy.
 
-For x64 systems without visible AVX2 support, OpenCode selects its baseline binary. If this add-on runs in a VM on an AVX2-capable host, enable host CPU passthrough; generic QEMU/KVM CPU models can hide AVX2 and force the baseline binary unnecessarily. There is a known upstream baseline OOM issue tracked at `anomalyco/opencode#20988`.
+#### CPU requirements
+
+OpenCode is distributed as a Bun-compiled binary, so Bun's CPU floor is OpenCode's: an x64 processor must support **SSE4.2** — the x86-64-v2 level, meaning Intel Nehalem (2008) or newer, or AMD Bulldozer (2011) / Jaguar (2013) or newer. On a CPU below that line every published OpenCode binary exits immediately with `Illegal instruction (core dumped)`, and no add-on setting changes it. The add-on checks for SSE4.2 at start-up and states the reason in its log rather than leaving you with a bare crash. ARM64 (aarch64) is unaffected.
+
+Above that floor there are two x64 builds. The regular build additionally requires **AVX2** (Intel Haswell, 2013, or newer); when AVX2 is not visible the add-on automatically selects OpenCode's *baseline* build. Two things to know about that fallback:
+
+- **Upstream currently publishes the regular AVX2 binary inside the baseline package** ([anomalyco/opencode#33595](https://github.com/anomalyco/opencode/issues/33595)). For the OpenCode versions shipped at the time of writing, `opencode-linux-x64-baseline` and `opencode-linux-x64` are byte-identical, so baseline mode does not currently help a CPU that lacks AVX2. This is an upstream packaging problem the add-on cannot work around; the **CPU mode** option is kept because it starts working again the moment upstream publishes a genuine baseline build.
+- If the add-on runs in a VM on an AVX2-capable host, enable host CPU passthrough — generic QEMU/KVM CPU models hide AVX2 and force baseline mode unnecessarily.
+
+There is also a known upstream baseline OOM issue tracked at [anomalyco/opencode#20988](https://github.com/anomalyco/opencode/issues/20988).
 
 #### Environment Variables Example
 

--- a/ha_opencode/rootfs/etc/s6-overlay/s6-rc.d/init-opencode/run
+++ b/ha_opencode/rootfs/etc/s6-overlay/s6-rc.d/init-opencode/run
@@ -321,12 +321,33 @@ fi
 
 # ==============================================================================
 # CPU Capability Detection - record diagnostics for OpenCode's runtime selector
+#
+# OpenCode ships Bun-compiled binaries, so Bun's CPU floor is OpenCode's. The
+# regular x64 build targets Haswell (AVX2); the x64 "baseline" build targets
+# Nehalem, which still requires SSE4.2 (the x86-64-v2 level). Below SSE4.2 no
+# published build starts at all, and the only useful thing this add-on can do
+# is name the cause instead of leaving the user with a bare "Illegal
+# instruction (core dumped)".
 # ==============================================================================
+
+# Recorded when the CPU is below Bun's floor, so the runtime setup below can
+# explain a failed binary rather than reporting a generic execution failure.
+CPU_UNSUPPORTED_MARKER=/data/.cpu_unsupported
 
 warn_baseline_mode() {
     bashio::log.warning "OpenCode x64 baseline mode may be used because AVX2 is not visible to the container."
     bashio::log.warning "If this add-on runs in a VM on an AVX2-capable host, enable host CPU passthrough; generic QEMU/KVM CPU models can hide AVX2."
+    bashio::log.warning "Upstream currently publishes the regular AVX2 binary inside the x64 baseline package, so baseline mode may still fail with an illegal instruction: https://github.com/anomalyco/opencode/issues/33595"
     bashio::log.warning "Known upstream baseline OOM issue: https://github.com/anomalyco/opencode/issues/20988"
+}
+
+report_unsupported_cpu() {
+    local model_name
+    model_name=$(awk -F': ' '/^model name/ {print $2; exit}' /proc/cpuinfo 2>/dev/null)
+    bashio::log.error "This CPU cannot run OpenCode: ${model_name:-unknown CPU} does not support SSE4.2."
+    bashio::log.error "OpenCode is built with Bun, whose oldest supported target (the x64 'baseline' build) requires SSE4.2 - the x86-64-v2 level, meaning Intel Nehalem (2008) or newer, or AMD Bulldozer (2011) / Jaguar (2013) or newer."
+    bashio::log.error "No published OpenCode binary, regular or baseline, will start on this hardware; it exits immediately with 'Illegal instruction (core dumped)'."
+    bashio::log.error "The rest of the add-on still works, but OpenCode itself cannot run on this machine. Setting CPU mode to 'baseline' does not change this."
 }
 
 detect_cpu_capabilities() {
@@ -335,8 +356,13 @@ detect_cpu_capabilities() {
     local cpu_flags=""
     local has_avx2=false
     local has_avx=false
+    local has_sse42=false
 
     machine=$(uname -m)
+
+    # Cleared every boot so moving the disk to a newer machine, or giving the VM
+    # a better CPU model, drops the marker instead of leaving it stale.
+    rm -f "${CPU_UNSUPPORTED_MARKER}"
 
     if [ -f /proc/cpuinfo ]; then
         cpu_flags=$(awk -F': ' '/^flags/ {print $2; exit}' /proc/cpuinfo)
@@ -350,6 +376,10 @@ detect_cpu_capabilities() {
         has_avx=true
     fi
 
+    if echo "${cpu_flags}" | grep -q '\bsse4_2\b'; then
+        has_sse42=true
+    fi
+
     if [ "${machine}" = "aarch64" ] || [ "${machine}" = "arm64" ]; then
         echo "regular" > /data/.cpu_mode
         if [ "${cpu_mode_config}" = "baseline" ]; then
@@ -357,6 +387,16 @@ detect_cpu_capabilities() {
         else
             bashio::log.info "ARM64 architecture detected - using regular OpenCode binary"
         fi
+        return
+    fi
+
+    # Below SSE4.2 the binary choice is moot - neither build runs - so say so
+    # once, plainly, and still record a mode so the rest of start-up proceeds
+    # normally and the message stays visible in the add-on log.
+    if [ "${has_sse42}" != "true" ]; then
+        printf '1\n' > "${CPU_UNSUPPORTED_MARKER}"
+        report_unsupported_cpu
+        echo "baseline" > /data/.cpu_mode
         return
     fi
 
@@ -452,7 +492,11 @@ setup_opencode_runtime() {
     if [ "${use_persistent}" != "true" ]; then
         opencode_select_package_binary "${bundled_package}" "${cpu_mode}" || true
         if ! opencode_bin_runs "${bundled_bin}"; then
-            bashio::log.error "Bundled OpenCode binary failed to execute; the terminal may not start correctly"
+            if [ -f "${CPU_UNSUPPORTED_MARKER}" ]; then
+                bashio::log.error "Bundled OpenCode binary failed to execute because this CPU lacks SSE4.2 (see the CPU message above); the terminal will start but OpenCode will not run"
+            else
+                bashio::log.error "Bundled OpenCode binary failed to execute; the terminal may not start correctly"
+            fi
         fi
     fi
 

--- a/ha_opencode/translations/en.yaml
+++ b/ha_opencode/translations/en.yaml
@@ -80,7 +80,7 @@ configuration:
 
   cpu_mode:
     name: "CPU mode"
-    description: "Which OpenCode binary to run. 'auto' detects your CPU (recommended), 'baseline' forces the build for older CPUs without AVX2, and 'regular' forces the standard build."
+    description: "Which OpenCode binary to run. 'auto' detects your CPU (recommended), 'baseline' selects the build meant for older CPUs without AVX2, and 'regular' forces the standard build. OpenCode requires a CPU with SSE4.2 (Intel Nehalem 2008+, AMD Bulldozer 2011+) in every mode. Note that upstream currently ships the same binary in both packages, so 'baseline' does not presently help a CPU without AVX2."
 
   enable_server:
     name: "OpenCode LAN server"

--- a/ha_opencode_beta/CHANGELOG.md
+++ b/ha_opencode_beta/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.3.9b2
+
+A crash with no explanation, and an option that had stopped meaning what it said.
+
+- **A CPU too old for OpenCode now says so instead of crashing ([issue #86](https://github.com/magnusoverli/opencode/issues/86), reported by [@deanhalllincoln](https://github.com/deanhalllincoln))** — on an AMD G-T56N, `opencode --version` died with `Illegal instruction (core dumped)` and nothing anywhere explained why. OpenCode ships as a Bun-compiled binary, so Bun's CPU floor is OpenCode's, and Bun's oldest supported target — the x64 *baseline* build — still requires SSE4.2, the x86-64-v2 level. That processor is a 2011 Bobcat: it has SSE4a and POPCNT but neither SSE4.1 nor SSE4.2, so it sits below the floor and no published OpenCode binary can start on it. The add-on now checks for SSE4.2 at start-up and states that in the log, naming the CPU and the requirement, and the error raised when the binary then fails to execute points at the CPU instead of reporting a generic execution failure. Everything else still comes up, so the message is readable in the add-on log. This does not make OpenCode run on such hardware — nothing can — but it replaces a bare crash with a diagnosis.
+- **The `baseline` CPU mode does not currently do what it promised** — the add-on detects missing AVX2 and selects `opencode-linux-x64-baseline` for it, which is the right thing to do, but upstream is publishing the regular AVX2 binary inside that package. For the shipped OpenCode versions the two are byte-identical: same SHA-256, tarballs differing only by the package name in `package.json`, and the "baseline" binary disassembles with AVX and SSE4.1 instructions still in it. The fallback is therefore inert, and machines with SSE4.2 but no AVX2 — Sandy Bridge and Ivy Bridge boxes, common enough as Home Assistant hosts — hit the same illegal instruction the option exists to avoid. The documentation and the option description claimed otherwise and now say what is true, and the start-up warning links the upstream report ([anomalyco/opencode#33595](https://github.com/anomalyco/opencode/issues/33595)). The option is kept rather than removed, because it starts working again the moment upstream publishes a genuine baseline build.
+- **Minimum hardware is documented** — the README and the add-on documentation both state the SSE4.2 floor and the separate AVX2 distinction up front, instead of leaving it to be discovered by crashing.
+
 ## 2.3.9b1
 
 Two things users could not do, and a quieter one about what every request costs. The first two came in as issues with the diagnostic work already done; the third came out of chasing why a local model took two minutes to say hello.

--- a/ha_opencode_beta/DOCS.md
+++ b/ha_opencode_beta/DOCS.md
@@ -85,7 +85,13 @@ By default, **OpenCode update policy** is set to `bundled`: the add-on uses the 
 
 Set the policy to `latest` to follow upstream OpenCode releases. The add-on starts immediately on the bundled (or an existing healthy persistent) binary, then refreshes `opencode-ai@latest` into `/data/.npm-global` **in the background**; the newer version becomes active for the next OpenCode session. The background update never blocks start-up and is skipped automatically when available memory is below ~1.5 GB. An interrupted or non-working update is discarded so the add-on keeps using the known-good bundled copy.
 
-For x64 VM installs, make sure the guest can see AVX2 when the host supports it. Generic QEMU/KVM CPU models can hide AVX2 and force OpenCode's baseline binary.
+### CPU requirements
+
+OpenCode is a Bun-compiled binary, so Bun's CPU floor applies: an x64 processor must support **SSE4.2** (the x86-64-v2 level — Intel Nehalem/2008 or newer, AMD Bulldozer/2011 or Jaguar/2013 or newer). Below that line every OpenCode binary exits immediately with `Illegal instruction (core dumped)` and no add-on setting changes it; the add-on detects this at start-up and says so in its log. ARM64 is unaffected.
+
+The regular x64 build additionally requires **AVX2** (Haswell/2013 or newer), and the add-on falls back to OpenCode's *baseline* build when AVX2 is missing. Note that upstream currently publishes the regular AVX2 binary inside the baseline package ([anomalyco/opencode#33595](https://github.com/anomalyco/opencode/issues/33595)) — the two are byte-identical in the shipped versions, so baseline mode does not presently rescue a CPU without AVX2.
+
+For x64 VM installs, make sure the guest can see AVX2 when the host supports it. Generic QEMU/KVM CPU models can hide AVX2 and force OpenCode's baseline binary unnecessarily.
 
 ## Native Home Assistant MCP Bridge (Beta)
 

--- a/ha_opencode_beta/translations/en.yaml
+++ b/ha_opencode_beta/translations/en.yaml
@@ -80,7 +80,7 @@ configuration:
 
   cpu_mode:
     name: "CPU mode"
-    description: "Which OpenCode binary to run. 'auto' detects your CPU (recommended), 'baseline' forces the build for older CPUs without AVX2, and 'regular' forces the standard build."
+    description: "Which OpenCode binary to run. 'auto' detects your CPU (recommended), 'baseline' selects the build meant for older CPUs without AVX2, and 'regular' forces the standard build. OpenCode requires a CPU with SSE4.2 (Intel Nehalem 2008+, AMD Bulldozer 2011+) in every mode. Note that upstream currently ships the same binary in both packages, so 'baseline' does not presently help a CPU without AVX2."
 
   enable_server:
     name: "OpenCode LAN server"


### PR DESCRIPTION
Closes #86.

## What was wrong

The reporter's add-on installed fine but every `opencode` invocation died with `Illegal instruction (core dumped)`, with nothing anywhere explaining why. Investigation found two separate things.

**1. The CPU is below OpenCode's hard floor.** OpenCode ships Bun-compiled binaries, so Bun's CPU requirement is OpenCode's. Bun's *oldest* supported target — the x64 `baseline` build — targets Nehalem and still requires **SSE4.2**. The reporter's AMD G-T56N is a 2011 Bobcat: it has `sse4a`, `popcnt`, `ssse3`, `cx16`, but neither `sse4_1` nor `sse4_2`, so it is x86-64-v1 and sits below the floor. No published OpenCode binary can start on it, and no add-on setting changes that.

**2. The `baseline` CPU mode is currently inert anyway.** The add-on correctly detects missing AVX2 and hardlinks `opencode-linux-x64-baseline/bin/opencode` into place — but upstream is publishing the regular AVX2 binary inside that package:

```
opencode-linux-x64@1.18.10           bin/opencode  sha256 2735f786be49…
opencode-linux-x64-baseline@1.18.10  bin/opencode  sha256 2735f786be49…
```

Byte-identical. The tarballs are genuinely distinct (sha1s match the registry, so this is not a download artifact) and differ *only* by the 9-character package name in `package.json`. Disassembly of the "baseline" binary confirms it: ~5,900 `ymm` operands in one 3 MB window of `.text`, plus SSE4.1 `pblendvb`/`pmovzxbw`. Comparing `unpackedSize` across releases (a delta of exactly 9 = identical binary) shows a real baseline build shipped once, in 1.2.0, and not in 1.0.141 / 1.4.0 / 1.16.0 / 1.18.10. This is open upstream as [anomalyco/opencode#33595](https://github.com/anomalyco/opencode/issues/33595).

This second point is the wider one: it affects users with **SSE4.2 but no AVX2** — Sandy/Ivy Bridge NUCs and thin clients, common HA hosts. `DOCS.md` and the `cpu_mode` option told those users baseline would rescue them. It cannot, on current OpenCode. They *would* be rescued by a genuine baseline build.

## What this changes

1. **Detect SSE4.2 at start-up and report the cause.** `detect_cpu_capabilities` now gates on `sse4_2` and, when it is missing, logs the CPU model, the requirement (x86-64-v2 — Intel Nehalem 2008+, AMD Bulldozer 2011+ / Jaguar 2013+), and the fact that no build will start. Start-up then proceeds normally so the message stays readable in the add-on log, and the subsequent "binary failed to execute" error points at the CPU instead of reporting a generic execution failure.
2. **Document the floor** in `README.md` and both `DOCS.md` files, under a new *CPU requirements* section.
3. **Correct the baseline claim** in `DOCS.md`, the `cpu_mode` option description (both channels), and the start-up warning, which now links #33595. The option is kept rather than removed — it starts working again the moment upstream publishes a real baseline build.

This does **not** make OpenCode run on the reporter's hardware. Nothing can. It replaces an unexplained crash with a diagnosis, and stops the documentation promising a fallback that currently does nothing.

## Verification

Extracted the real `detect_cpu_capabilities` into a harness with stubbed bashio and fixture `/proc/cpuinfo`, then ran it against actual CPU flag sets — including the reporter's verbatim flag list from the issue:

| case | cpu_mode | → mode | unsupported |
|---|---|---|---|
| AMD G-T56N (issue #86) | auto | baseline | **yes** |
| AMD G-T56N | baseline | baseline | **yes** |
| AMD G-T56N | regular | baseline | **yes** |
| Ivy Bridge i5-3470 (avx, no avx2) | auto | baseline | no |
| Haswell+ i5-8400 (avx2) | auto | regular | no |
| Haswell+ i5-8400 | baseline | baseline | no |

All 6 pass. `bash -n` clean on both modified shell files; all touched YAML parses.

## Notes for review

- The marker file `/data/.cpu_unsupported` is cleared on every boot, so moving the disk to a newer machine or giving the VM a better CPU model drops it rather than leaving it stale.
- Changelog entry goes to `ha_opencode_beta/CHANGELOG.md` as `2.3.9b2` per RELEASING.md; no version bump in `config.yaml`, since the release workflow owns that at tag time.
- **Possible follow-up, deliberately not included:** on an unsupported CPU the background `latest` updater will still install a binary that cannot run. Gating that on the same marker would save the memory and network, but it is a fourth behaviour change and outside what this PR was scoped to.
